### PR TITLE
Removed strict lib requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-test-utils"
-version = "0.2.1"
+version = "0.2.2"
 description = "Utils for testing infructructure created by csm-sandbox"
 authors = ["OTC customer service monitroing team"]
 license = "Apache-2.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ocomone >= 0.3.1
 requests >= 2.22
 influx_line_protocol >= 0.1.3
-wrapt == 1.11.2
-PyYAML == 5.1.2
-botocore == 1.12.242
-boto3 == 1.9.238
+wrapt
+PyYAML
+botocore
+boto3


### PR DESCRIPTION
When installing starting scenario1 test:
```log
csm-test-utils 0.2.1 has requirement boto3==1.9.238, but you'll have boto3 1.10.13 which is incompatible.
csm-test-utils 0.2.1 has requirement botocore==1.12.242, but you'll have botocore 1.13.13 which is incompatible.
```