### PR TITLE
Get rid of pypoetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,6 @@
-[tool.poetry]
-name = "csm-test-utils"
-version = "0.2.14"
-description = "Utils for testing infrastructure created by customer service monitoring"
-authors = ["OTC customer service monitoring team"]
-license = "Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/opentelekomcloud-infra/csm-test-utils"
-
-[tool.poetry.dependencies]
-python = "^3.7"
-
-ocomone = "^0.4.1"
-requests = "^2.22"
-influx_line_protocol = "^0.1.3"
-wrapt = "^1.11.2"
-PyYAML = "^5.1.2"
-botocore = ">=1.13"
-boto3 = ">=1.10"
-flask = "^1.1"
-
-[tool.poetry.dev-dependencies]
-
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = [
+  "setuptools >= 40.9.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+ocomone>=0.4.1
+requests>=2.22
+influx_line_protocol>=0.1.3
+wrapt>=1.11
+PyYAML>=5.1.2,<5.2
+botocore>=1.13
+boto3>=1.10
+flask>=1.1,<1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = csm-test-utils
+version = 0.2.15
+summary = Utils for testing infrastructure created by customer service monitoring
+author = OTC customer service monitoring team
+license = Apache-2.0
+license_file = LICENSE
+description-file = README.md
+url = https://github.com/opentelekomcloud-infra/csm-test-utils
+
+classifiers =
+      Framework :: Flask
+      Programming Language :: Python :: 3
+
+[files]
+packages =
+  csm_test_utils
+
+[wheel]
+universal = 1
+
+[options]
+include_package_data = True
+packages = find:
+install_requires =
+    ocomone>=0.4.1
+    requests>=2.22
+    influx_line_protocol>=0.1.3
+    wrapt>=1.11
+    PyYAML>=5.1.2,<5.2
+    botocore>=1.13
+    boto3>=1.10
+    flask>=1.1,<1.2


### PR DESCRIPTION
There is a set of jobs in zuul CI for publishing python packages. It won't work with poetry, so we have to replace it with a standard toolset.